### PR TITLE
add older patch version to the list  (1.22.13, 1.23.10, 1.24.4, 1.25.0)

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -19,9 +19,13 @@ jobs:
           - quay.io/kairos/core-ubuntu-22-lts:v1.1.1
         k3s-version:
           - v1.25.2+k3s1
+          - v1.25.0+k3s1
           - v1.24.6+k3s1
+          - v1.24.4+k3s1
           - v1.23.12+k3s1
+          - v1.23.10+k3s1
           - v1.22.15+k3s1
+          - v1.22.13+k3s1
     env:
       REGISTRY: quay.io
       REGISTRY_USER: ${{ secrets.QUAY_USERNAME }}


### PR DESCRIPTION
We don’t need these old versions (1.22.13, 1.23.10, 1.24.4, 1.25.0) for rke2/k3s, but will just build the images with new naming convention just because the pack is already out there