### PR TITLE
Adding etcdctl in k3s provider

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -77,6 +77,8 @@ docker:
         && INSTALL_K3S_SKIP_START="true" INSTALL_K3S_SKIP_ENABLE="true" bash installer.sh agent \
         && rm -rf installer.sh
 
+    RUN curl -sL https://github.com/etcd-io/etcd/releases/download/v3.5.5/etcd-v3.5.5-linux-amd64.tar.gz | sudo tar -zxv --strip-components=1 -C /usr/local/bin
+
     COPY +build-provider/agent-provider-k3s /system/providers/agent-provider-k3s
 
     ENV OS_ID=${BASE_IMAGE_NAME}-k3s


### PR DESCRIPTION
Adding `etcdctl` in k3s provider image as there is no etcd pod in the cluster and k3s does not bundle etcdctl. So, we will need to add it in provider image. https://docs.k3s.io/advanced#using-etcdctl 

For `pxk-e` and `rke2`, commands will be executed in etcd pod. So, no `etcdctl` is required.
Though I have found out that after removing CP from k3s cluster, etcd member is also removed but still adding it as script will verify if member is removed or not.

Signed-off-by: Rishi <rishi.anand0@gmail.com>