### PR TITLE
fix: Align module name w/ repo URL

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/kairos-io/kairos/provider-k3s
+module github.com/kairos-io/provider-k3s
 
 go 1.18
 

--- a/main.go
+++ b/main.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/kairos-io/kairos-sdk/clusterplugin"
-	"github.com/kairos-io/kairos/provider-k3s/api"
+	"github.com/kairos-io/provider-k3s/api"
 
 	yip "github.com/mudler/yip/pkg/schema"
 	"github.com/sirupsen/logrus"


### PR DESCRIPTION
Resolves discrepancy between module name & repo URL:
```bash
❯ mkdir foo
❯ cd foo
❯ go mod init foo.com/bar
go: creating new go.mod: module foo.com/bar
❯ go get github.com/kairos-io/provider-k3s
go: github.com/kairos-io/provider-k3s@upgrade (v1.2.3) requires github.com/kairos-io/provider-k3s@v1.2.3: parsing go.mod:
	module declares its path as: github.com/kairos-io/kairos/provider-k3s
	        but was required as: github.com/kairos-io/provider-k3s
❯ go get github.com/kairos-io/provider-k3s@v2.3.2
go: github.com/kairos-io/provider-k3s@v2.3.2: invalid version: module contains a go.mod file, so module path must match major version ("github.com/kairos-io/provider-k3s/v2")
```