### PR TITLE
Fix go build for provider

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -62,7 +62,7 @@ lint:
 
 build-provider:
     FROM +go-deps
-    DO +BUILD_GOLANG --BIN=agent-provider-k3s --SRC=main.go
+    DO +BUILD_GOLANG --BIN=agent-provider-k3s --SRC=.
 
 build-provider-package:
     DO +VERSION


### PR DESCRIPTION
Since constants.go is defined we can't use main.go as the only source.