### PR TITLE
chore: update golang builder image to hardened image registry

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -22,7 +22,7 @@ build-cosign:
     SAVE ARTIFACT /ko-app/cosign cosign
 
 go-deps:
-    FROM us-docker.pkg.dev/palette-images/build-base-images/golang:${GOLANG_VERSION}-alpine
+    FROM us-central1-docker.pkg.dev/palette-images-dev/hardened-images/builder/golang:${GOLANG_VERSION}-alpine
     WORKDIR /build
     COPY go.mod go.sum ./
     RUN go mod download
@@ -54,9 +54,8 @@ VERSION:
     SAVE ARTIFACT VERSION VERSION
 
 lint:
-    FROM golang:$GOLANG_VERSION
+    FROM +go-deps
     RUN wget -O- -nv https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s $GOLINT_VERSION
-    WORKDIR /build
     COPY . .
     RUN golangci-lint run
 


### PR DESCRIPTION
## Summary
- Update `go-deps` base image from `us-docker.pkg.dev/palette-images/build-base-images/golang` to `us-central1-docker.pkg.dev/palette-images-dev/hardened-images/builder/golang`
- Update `lint` target to reuse `+go-deps` as base image instead of `golang:$GOLANG_VERSION`

## Test plan
- [ ] Verify `+go-deps` target builds successfully with the new image
- [ ] Verify `+lint` target runs successfully
- [ ] Verify `+build-provider` completes successfully