### PR TITLE
PE-8682: fix k3s bootstrap crash

### DIFF
--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -196,7 +196,7 @@ func parseStages(cluster clusterplugin.Cluster, files []yip.File, systemName str
 			If:   "[ -x /bin/systemctl ]",
 			Commands: []string{
 				fmt.Sprintf("systemctl enable %s", systemName),
-				fmt.Sprintf("systemctl restart %s", systemName),
+				fmt.Sprintf("systemctl start %s", systemName),
 			},
 		},
 	)


### PR DESCRIPTION
fix: replace unconditional `restart` with idempotent `start` for k3s service

systemctl restart k3s in the Enable Systemd Services yip stage sends SIGTERM
to k3s mid-bootstrap, killing k3s before it completes. This leaves an empty bbolt db
and causes a permanent "no bootstrap data found in datastore" crash loop.

Replace `systemctl restart` with `systemctl start`, which is a no-op when the
service is already active