### PR TITLE
chore(deps): bump go directive to 1.26.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kairos-io/provider-k3s
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/kairos-io/kairos-sdk v0.9.3


### PR DESCRIPTION
## Summary
Aligns the go directive to 1.26.4 to pick up the latest toolchain security fixes.

## Test plan
- [x] go mod tidy
- [x] go build ./...