### PR TITLE
PE-9114: fix proxy env race on boot by conditional restart

### DIFF
--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -196,7 +196,8 @@ func parseStages(cluster clusterplugin.Cluster, files []yip.File, systemName str
 			If:   "[ -x /bin/systemctl ]",
 			Commands: []string{
 				fmt.Sprintf("systemctl enable %s", systemName),
-				fmt.Sprintf("systemctl start %s", systemName),
+				"systemctl daemon-reload",
+				fmt.Sprintf("systemctl is-active --quiet %s && systemctl restart %s || systemctl start %s", systemName, systemName, systemName),
 			},
 		},
 	)


### PR DESCRIPTION
## Summary

- The previous PE-8682 fix (21f71bf) reverted `systemctl restart` → `systemctl start` to prevent killing a bootstrapping k3s on first boot
- However, `systemctl start` is a **no-op** when systemd has already auto-started `k3s.service` before the yip `boot.before` stage writes `/etc/default/k3s` (the proxy env file)
- This leaves containerd running **without `HTTP_PROXY` / `HTTPS_PROXY`**, causing `ImagePullBackOff` on every pod scheduled to that node — blocking K8s upgrades entirely

### Root cause timeline (observed on edge host 10.10.200.242)

```
01:42:47  systemd auto-starts k3s.service     ← reads /etc/default/k3s (DOESN'T EXIST YET)
01:42:47  kairos-agent: boot.before begins     ← still processing earlier steps
01:42:52  kairos-agent: writes /etc/default/k3s ← 5 seconds LATE
01:42:52  kairos-agent: systemctl start k3s    ← NO-OP (already running without proxy)
```

### Fix

Replace the unconditional `systemctl start` with:
1. `systemctl daemon-reload` — ensure systemd re-reads the freshly-written env file
2. `systemctl is-active --quiet k3s && systemctl restart k3s || systemctl start k3s` — restart only if already running (proxy race); otherwise start cleanly (first boot)

| Scenario | `start` (before) | `restart` (PE-8682 original) | **This fix** |
|---|---|---|---|
| First boot (k3s not running) | ✅ start | ❌ kills bootstrapping etcd | ✅ start |
| Reboot with proxy (k3s auto-started) | ❌ no-op, no proxy | ✅ restart | ✅ restart |

## Test plan

- [ ] Deploy on edge host behind proxy, verify k3s picks up `HTTP_PROXY`/`HTTPS_PROXY` after reboot
- [ ] Fresh single-node bootstrap: verify k3s starts cleanly without crash-loop
- [ ] K8s upgrade on proxy cluster: verify upgrade task pods can pull images on all nodes
- [ ] Verify `/proc/$(pgrep k3s)/environ` contains proxy vars after boot