### PR TITLE
PE-9114: handle Type=notify activating state in k3s restart check

### DIFF
--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -197,7 +197,7 @@ func parseStages(cluster clusterplugin.Cluster, files []yip.File, systemName str
 			Commands: []string{
 				fmt.Sprintf("systemctl enable %s", systemName),
 				"systemctl daemon-reload",
-				fmt.Sprintf("systemctl is-active --quiet %s && systemctl restart %s || systemctl start %s", systemName, systemName, systemName),
+				fmt.Sprintf("if systemctl is-active --quiet %s || systemctl show -p ActiveState --value %s | grep -q activating; then systemctl restart %s; else systemctl start %s; fi", systemName, systemName, systemName, systemName),
 			},
 		},
 	)


### PR DESCRIPTION
## Summary

Follow-up to PR #136. The previous fix used `systemctl is-active --quiet` to detect a running k3s and restart it to pick up the proxy env file. However, **k3s.service is `Type=notify`** and takes ~17s to become "active" (etcd reconciliation + `sd_notify(READY=1)`). The yip `boot.before` stage runs at ~7s — while k3s is still **"activating"**. `is-active` returns false for "activating", so it fell through to `start` (no-op) and k3s was never restarted.

### Boot timeline (confirmed on 10.10.206.142, stylus v4.9.24-rc.1)

```
07:52:06  systemd auto-starts k3s       → state = "activating"
07:52:13  boot.before runs our fix:
            is-active --quiet k3s       → FALSE ("activating" ≠ "active")
            falls to: start k3s        → no-op (already starting)
07:52:23  k3s sends sd_notify(READY=1) → state = "active" — 10s too late
```

k3s process (PID 3317) **never restarted** — ran entire session without proxy env.

### Fix

Check for **both** `active` and `activating` states before deciding to restart:

```sh
if systemctl is-active --quiet k3s || \
   systemctl show -p ActiveState --value k3s | grep -q activating; then
    systemctl restart k3s   # picks up /etc/default/k3s
else
    systemctl start k3s     # first boot, clean start
fi
```

| Scenario | k3s state at check time | Action | Safe? |
|---|---|---|---|
| First boot (never enabled) | inactive | `start` | Yes — clean bootstrap, no PE-8682 |
| Repave reboot, k3s fully ready | active | `restart` | Yes — etcd data exists |
| Repave reboot, k3s mid-bootstrap | **activating** | `restart` | Yes — etcd data exists from prior install |

## Test plan

- [ ] Deploy on edge host behind proxy, k3s repave upgrade → verify k3s process has proxy env after reboot
- [ ] Fresh single-node bootstrap → verify no crash-loop (PE-8682 regression check)
- [ ] Verify on `Type=notify` service: `systemctl show -p ActiveState --value k3s` returns "activating" during bootstrap window
- [ ] Check `/proc/$(pgrep -f 'k3s server')/environ` contains `HTTP_PROXY` after boot