### PR TITLE
PE-9154: stop systemd auto-starting k3s before its config is rendered

### DIFF
--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -199,7 +199,8 @@ func parseStages(cluster clusterplugin.Cluster, files []yip.File, systemName str
 				fmt.Sprintf("systemctl disable %s", systemName),
 				fmt.Sprintf("systemctl enable --runtime %s", systemName),
 				"systemctl daemon-reload",
-				// Nodes carrying the old persistent link may already be running the stale config.
+				// A node still holding the old persistent link may have auto-started k3s before
+				// this stage rendered config.yaml; start is a no-op on an already-live unit.
 				fmt.Sprintf("if systemctl is-active --quiet %[1]s || systemctl show -p ActiveState --value %[1]s | grep -q activating; then systemctl restart %[1]s; else systemctl start %[1]s; fi", systemName),
 			},
 		},

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -195,9 +195,12 @@ func parseStages(cluster clusterplugin.Cluster, files []yip.File, systemName str
 			Name: constants.EnableSystemdServices,
 			If:   "[ -x /bin/systemctl ]",
 			Commands: []string{
-				fmt.Sprintf("systemctl enable %s", systemName),
+				// A /run link is cleared each boot, so systemd can never start k3s before this stage renders config.yaml.
+				fmt.Sprintf("systemctl disable %s", systemName),
+				fmt.Sprintf("systemctl enable --runtime %s", systemName),
 				"systemctl daemon-reload",
-				fmt.Sprintf("if systemctl is-active --quiet %s || systemctl show -p ActiveState --value %s | grep -q activating; then systemctl restart %s; else systemctl start %s; fi", systemName, systemName, systemName, systemName),
+				// Nodes carrying the old persistent link may already be running the stale config.
+				fmt.Sprintf("if systemctl is-active --quiet %[1]s || systemctl show -p ActiveState --value %[1]s | grep -q activating; then systemctl restart %[1]s; else systemctl start %[1]s; fi", systemName),
 			},
 		},
 	)

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -3,11 +3,15 @@ package provider
 import (
 	"bytes"
 	_ "embed"
+	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/kairos-io/kairos-sdk/clusterplugin"
 	"gopkg.in/yaml.v3"
+
+	"github.com/kairos-io/provider-k3s/pkg/constants"
 )
 
 func Test_parseOptions(t *testing.T) {
@@ -191,6 +195,39 @@ func Test_decodeOptions(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := decodeOptions(tt.args.in); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("decodeOptions() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_systemdStageDoesNotPersistEnablement(t *testing.T) {
+	for _, role := range []clusterplugin.Role{clusterplugin.RoleInit, clusterplugin.RoleWorker} {
+		t.Run(string(role), func(t *testing.T) {
+			cluster := clusterplugin.Cluster{ClusterToken: "token", ControlPlaneHost: "localhost", Role: role}
+			systemName := serverSystemName
+			if role == clusterplugin.RoleWorker {
+				systemName = agentSystemName
+			}
+
+			var commands []string
+			for _, stage := range parseStages(cluster, parseFiles(cluster, systemName), systemName) {
+				if stage.Name == constants.EnableSystemdServices {
+					commands = stage.Commands
+				}
+			}
+			if commands == nil {
+				t.Fatalf("no %q stage found", constants.EnableSystemdServices)
+			}
+
+			joined := strings.Join(commands, "\n")
+			if strings.Contains(joined, fmt.Sprintf("systemctl enable %s", systemName)) {
+				t.Errorf("stage persistently enables %s; systemd would auto-start it before config.yaml is rendered:\n%s", systemName, joined)
+			}
+			if !strings.Contains(joined, fmt.Sprintf("systemctl enable --runtime %s", systemName)) {
+				t.Errorf("stage does not runtime-enable %s:\n%s", systemName, joined)
+			}
+			if !strings.Contains(joined, fmt.Sprintf("systemctl disable %s", systemName)) {
+				t.Errorf("stage does not clear a pre-existing persistent link for %s:\n%s", systemName, joined)
 			}
 		})
 	}


### PR DESCRIPTION
`systemctl enable` writes the wants link under /etc/systemd/system, where it survives a reboot, while /etc/rancher/k3s/config.yaml is re-rendered by this stage on every
  boot. Systemd therefore starts k3s at network-online.target before the Palette-rendered config exists, and k3s bootstraps its datastore from vanilla defaults.

  On a cluster with a customised service-cidr this persists ServiceCIDR/kubernetes = [10.43.0.0/16] before the intended range is ever seen. The restart that follows
  migrates the stale object into managed etcd, ServiceCIDR reconciliation refuses to align the mismatch, kube-dns is never created at its intended ClusterIP, and every
  DNS-dependent add-on fails. The cluster cannot recover on its own.

  This is the same ordering bug as PE-8682. The start/restart command below has been rewritten three times (#127, #136, #137) and narrowed again on
  fix/pe-9160-k3s-bootstrap-restart, but each pass tunes how aggressively k3s is restarted *after* it has already come up misconfigured; none stop it coming up
  misconfigured. Link the unit into /run instead, which is cleared on every boot, so this stage is the only thing that ever starts k3s and there is nothing to recover
  from.

  ## Why the ordering is guaranteed

  Stages run in the order they are appended in `parseStages`. `Install K3s Configuration Files` renders /etc/rancher/k3s/config.yaml — yip applies a stage's `Files` before
   its `Commands`, so the config.d fragments land and are then jq-merged. `Enable Systemd Services` is appended after it, so config.yaml always exists before the unit is
  linked or started.

  The `Wants=`/`After=network-online.target` gate lives in the k3s unit file and is untouched by this PR. What changes is that when network-online.target is reached there
  is no wants link present yet, so systemd has nothing to pull in. The link appears only when this stage creates it, and the same stage then starts k3s explicitly.

  Command order within the stage matters: a plain `disable` does not clear a /run link, so `disable` must precede `enable --runtime`. `disable` exits 0 on a never-enabled
  unit, so a first boot is unaffected. yip's command plugin continues past a failed command, so neither can abort the stage.

  The conditional restart is kept. Nodes provisioned before this change still carry the persistent link, so on their first boot on this version k3s may already be running
  from the boot-time config, and `start` is a no-op on a live unit. The `activating` check is required because k3s is `Type=notify` and `is-active --quiet` reports false
  while it is still activating. It is a no-op on every subsequent boot.

  ## Validation

  A/B on a libvirt edge node under identical preconditions — config.yaml deleted, datastore wiped, and a boot.before delay to widen the window:

  - **without the change**: k3s reached `active` with no config present, persisted 10.43.0.0/16, and the later render produced 3x `inconsistent ServiceCIDR`, an
  unavailable API and unreachable kube-dns.
  - **with the change**: k3s stayed `inactive`/`disabled` for the entire window and started in the same second config.yaml was written. Correct ServiceCIDR, kube-dns at
  its intended address, 0 inconsistent.

  Fresh provision was checked separately. From the provisioning boot's journal, the unit file is written roughly two minutes before this stage runs, and k3s's first ever
  start is the one this stage issues — a new node has no wants link, so there is no race to lose. Confirmed live by wiping config, certs and datastore and rebooting: k3s
  stayed down for the full 131s until the stage started it, then came up on the intended range.

  ## Scope and tradeoffs

  Does not repair already-broken clusters, and they cannot be repaired by hand either. Deleting the stale ServiceCIDR is blocked by its finalizer until every Service in
  the stale range is deleted; even then allocation keeps failing until k3s is restarted, and the default `kubernetes` Service does not come back, because the allocator
  reports its address as already allocated with no object owning it. Reset or re-provision is the remediation.

  `systemctl is-enabled` reports `enabled-runtime` rather than `enabled` for a /run link. The only strict `== "enabled"` comparison found in stylus
  (pkg/systemd/systemd.go) is used for systemd-resolved, not k3s.

  k3s no longer comes up at all if this stage fails to run, instead of coming up misconfigured. That is deliberate: a visible failure rather than silent datastore
  corruption. Rollback on any node is a single `systemctl enable k3s`.

  The OpenRC branch keeps its persistent `rc-update add`, as no Palette Edge image uses OpenRC.