### PR TITLE
PE-9154: stop systemd auto-starting k3s before its config is rendered (4.8.x)

### DIFF
--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -195,8 +195,15 @@ func parseStages(cluster clusterplugin.Cluster, files []yip.File, systemName str
 			Name: constants.EnableSystemdServices,
 			If:   "[ -x /bin/systemctl ]",
 			Commands: []string{
-				fmt.Sprintf("systemctl enable %s", systemName),
-				fmt.Sprintf("systemctl restart %s", systemName),
+				// A /run link is cleared each boot, so systemd can never start k3s before this stage renders config.yaml.
+				fmt.Sprintf("systemctl disable %s", systemName),
+				fmt.Sprintf("systemctl enable --runtime %s", systemName),
+				"systemctl daemon-reload",
+				// A node still holding the old persistent link may have auto-started k3s before
+				// this stage rendered config.yaml; start is a no-op on an already-live unit.
+				// Conditional restart (from PE-8682/PE-9114) replaces unconditional restart on
+				// this branch so an activating Type=notify unit is not crashed mid-bootstrap.
+				fmt.Sprintf("if systemctl is-active --quiet %[1]s || systemctl show -p ActiveState --value %[1]s | grep -q activating; then systemctl restart %[1]s; else systemctl start %[1]s; fi", systemName),
 			},
 		},
 	)

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -3,11 +3,15 @@ package provider
 import (
 	"bytes"
 	_ "embed"
+	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/kairos-io/kairos-sdk/clusterplugin"
 	"gopkg.in/yaml.v3"
+
+	"github.com/kairos-io/provider-k3s/pkg/constants"
 )
 
 func Test_parseOptions(t *testing.T) {
@@ -191,6 +195,39 @@ func Test_decodeOptions(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := decodeOptions(tt.args.in); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("decodeOptions() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_systemdStageDoesNotPersistEnablement(t *testing.T) {
+	for _, role := range []clusterplugin.Role{clusterplugin.RoleInit, clusterplugin.RoleWorker} {
+		t.Run(string(role), func(t *testing.T) {
+			cluster := clusterplugin.Cluster{ClusterToken: "token", ControlPlaneHost: "localhost", Role: role}
+			systemName := serverSystemName
+			if role == clusterplugin.RoleWorker {
+				systemName = agentSystemName
+			}
+
+			var commands []string
+			for _, stage := range parseStages(cluster, parseFiles(cluster, systemName), systemName) {
+				if stage.Name == constants.EnableSystemdServices {
+					commands = stage.Commands
+				}
+			}
+			if commands == nil {
+				t.Fatalf("no %q stage found", constants.EnableSystemdServices)
+			}
+
+			joined := strings.Join(commands, "\n")
+			if strings.Contains(joined, fmt.Sprintf("systemctl enable %s", systemName)) {
+				t.Errorf("stage persistently enables %s; systemd would auto-start it before config.yaml is rendered:\n%s", systemName, joined)
+			}
+			if !strings.Contains(joined, fmt.Sprintf("systemctl enable --runtime %s", systemName)) {
+				t.Errorf("stage does not runtime-enable %s:\n%s", systemName, joined)
+			}
+			if !strings.Contains(joined, fmt.Sprintf("systemctl disable %s", systemName)) {
+				t.Errorf("stage does not clear a pre-existing persistent link for %s:\n%s", systemName, joined)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- Backport of #142 onto `rc-4.8` (4.8.x).
- Replaces persistent `systemctl enable` with `disable` + `enable --runtime` so systemd cannot auto-start k3s before config.yaml is rendered.
- **4.8 adaptation:** `rc-4.8` still used unconditional `systemctl restart`. This backport also brings the PE-8682/PE-9114 conditional start/restart (+ `daemon-reload`) that main already had when #142 landed, matching the [provider-rke2 PE-9154 port](https://github.com/kairos-io/provider-rke2/pull/105). Without that, an activating `Type=notify` unit would be crashed mid-bootstrap on the upgrade-path first boot.

Cherry-picked from `053c217` (#142) with conflict resolution as above.

## Test plan
- [x] `go test ./pkg/provider/...` on the backport branch
- [ ] Confirm stage order still renders config.yaml before Enable Systemd Services
- [ ] Fresh 4.8 provision: k3s first start is issued by this stage; ServiceCIDR matches intended range
- [ ] Upgrade-path first boot (old persistent wants link still present): conditional restart picks up re-rendered config without crashing an activating unit
- [ ] Subsequent boots: `enabled-runtime` only; restart branch is a no-op


Made with [Cursor](https://cursor.com)