### PR TITLE
PE-9154: keep the k3s unit intact on UKI images

### DIFF
--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -196,7 +196,8 @@ func parseStages(cluster clusterplugin.Cluster, files []yip.File, systemName str
 			If:   "[ -x /bin/systemctl ]",
 			Commands: []string{
 				// A /run link is cleared each boot, so systemd can never start k3s before this stage renders config.yaml.
-				fmt.Sprintf("systemctl disable %s", systemName),
+				// Not `systemctl disable`: on UKI the unit is a symlink into /opt/k8s, which disable deletes.
+				fmt.Sprintf("rm -f /etc/systemd/system/*.wants/%[1]s.service /etc/systemd/system/*.requires/%[1]s.service", systemName),
 				fmt.Sprintf("systemctl enable --runtime %s", systemName),
 				"systemctl daemon-reload",
 				// A node still holding the old persistent link may have auto-started k3s before

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -226,8 +226,11 @@ func Test_systemdStageDoesNotPersistEnablement(t *testing.T) {
 			if !strings.Contains(joined, fmt.Sprintf("systemctl enable --runtime %s", systemName)) {
 				t.Errorf("stage does not runtime-enable %s:\n%s", systemName, joined)
 			}
-			if !strings.Contains(joined, fmt.Sprintf("systemctl disable %s", systemName)) {
+			if !strings.Contains(joined, fmt.Sprintf("/etc/systemd/system/*.wants/%s.service", systemName)) {
 				t.Errorf("stage does not clear a pre-existing persistent link for %s:\n%s", systemName, joined)
+			}
+			if strings.Contains(joined, fmt.Sprintf("systemctl disable %s", systemName)) {
+				t.Errorf("stage disables %s; on UKI that deletes the unit symlink:\n%s", systemName, joined)
 			}
 		})
 	}


### PR DESCRIPTION
The defensive `systemctl disable` added by this branch does more than clear the enable state. On UKI provider images /etc/systemd/system/k3s.service is a symlink into /opt/k8s, laid down at build time by CanvOS slink, and systemd treats a unit symlink whose target sits outside its search paths as an alias to dismantle -- so disable deletes the unit itself. The following `enable --runtime` then fails with "Unit file k3s.service does not exist", `start` fails too, and kairos-agent is non-strict so it logs both and continues. The node boots without k3s, so there is no kubeconfig, no kube-vip and no cluster. Nothing recreates the symlink on reboot, so the node stays broken.

Remove the install links by path instead. That clears the persistent wants link exactly as disable did, but cannot touch the unit file. On non-UKI the resulting tree is identical to disable's apart from an empty multi-user.target.wants directory, which is inert and cannot occur on a real node. k3s.service declares only WantedBy=multi-user.target, so the wants and requires globs cover every link disable would have removed.