### PR TITLE
PE-9154: keep the k3s unit intact on UKI images (backport to rc-4.9)

### DIFF
--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -196,7 +196,8 @@ func parseStages(cluster clusterplugin.Cluster, files []yip.File, systemName str
 			If:   "[ -x /bin/systemctl ]",
 			Commands: []string{
 				// A /run link is cleared each boot, so systemd can never start k3s before this stage renders config.yaml.
-				fmt.Sprintf("systemctl disable %s", systemName),
+				// Not `systemctl disable`: on UKI the unit is a symlink into /opt/k8s, which disable deletes.
+				fmt.Sprintf("rm -f /etc/systemd/system/*.wants/%[1]s.service /etc/systemd/system/*.requires/%[1]s.service", systemName),
 				fmt.Sprintf("systemctl enable --runtime %s", systemName),
 				"systemctl daemon-reload",
 				// A node still holding the old persistent link may have auto-started k3s before

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -226,8 +226,11 @@ func Test_systemdStageDoesNotPersistEnablement(t *testing.T) {
 			if !strings.Contains(joined, fmt.Sprintf("systemctl enable --runtime %s", systemName)) {
 				t.Errorf("stage does not runtime-enable %s:\n%s", systemName, joined)
 			}
-			if !strings.Contains(joined, fmt.Sprintf("systemctl disable %s", systemName)) {
+			if !strings.Contains(joined, fmt.Sprintf("/etc/systemd/system/*.wants/%s.service", systemName)) {
 				t.Errorf("stage does not clear a pre-existing persistent link for %s:\n%s", systemName, joined)
+			}
+			if strings.Contains(joined, fmt.Sprintf("systemctl disable %s", systemName)) {
+				t.Errorf("stage disables %s; on UKI that deletes the unit symlink:\n%s", systemName, joined)
 			}
 		})
 	}


### PR DESCRIPTION
Backport of #146 to `rc-4.9`.

## Summary

- On UKI provider images, `systemctl disable` was deleting the `k3s.service` unit symlink (which lives in `/opt/k8s`) because systemd treats unit symlinks outside its search paths as aliases to dismantle
- This caused the node to boot without k3s — no kubeconfig, no kube-vip, no cluster
- Fix: remove the install links by path instead of using `systemctl disable`, which clears the persistent wants link without touching the unit file

## Original PR

https://github.com/kairos-io/provider-k3s/pull/146