### PR TITLE
fix(ci): build and publish FIPS provider packages

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,7 +25,52 @@ jobs:
         with:
           version: "latest"
       - run: earthly --ci +lint
-  build-provider-package:
+  build:
+    strategy:
+      matrix:
+        include:
+          - runner: ubuntu-24.04
+            platform: linux/amd64
+            fips: false
+            image_repository: us-docker.pkg.dev/palette-images/edge/kairos-io
+          - runner: ubuntu-24.04
+            platform: linux/amd64
+            fips: true
+            image_repository: us-docker.pkg.dev/palette-images-fips/edge/kairos-io
+          - runner: github-arm64-2c-8gb
+            platform: linux/arm64
+            fips: false
+            image_repository: us-docker.pkg.dev/palette-images/edge/kairos-io
+          - runner: github-arm64-2c-8gb
+            platform: linux/arm64
+            fips: true
+            image_repository: us-docker.pkg.dev/palette-images-fips/edge/kairos-io
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@master
+        with:
+          platforms: all
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@master
+      - uses: earthly/actions-setup@v1
+        with:
+          version: "latest"
+      - run: echo "${{ secrets.ARTIFACT_IMG_PUSH_EDGE }}" | base64 -d | docker login -u _json_key --password-stdin us-docker.pkg.dev
+      - run: earthly --ci --push --output --platform=${{ matrix.platform }} +build-provider-package --IMAGE_REPOSITORY=${{ matrix.image_repository }} --FIPS_ENABLED=${{ matrix.fips }}
+  push:
+    needs: build
+    strategy:
+      matrix:
+        include:
+          - fips: false
+            image_repository: us-docker.pkg.dev/palette-images/edge/kairos-io
+          - fips: true
+            image_repository: us-docker.pkg.dev/palette-images-fips/edge/kairos-io
     runs-on: ubuntu-24.04
     permissions:
       packages: write
@@ -42,4 +87,4 @@ jobs:
         with:
           version: "latest"
       - run: echo "${{ secrets.ARTIFACT_IMG_PUSH_EDGE }}" | base64 -d | docker login -u _json_key --password-stdin us-docker.pkg.dev
-      - run: earthly --ci --output --push +provider-package-all-platforms --IMAGE_REPOSITORY=us-docker.pkg.dev/palette-images/edge/kairos-io
+      - run: earthly --ci --push --output +provider-package-merge --IMAGE_REPOSITORY=${{ matrix.image_repository }} --FIPS_ENABLED=${{ matrix.fips }}

--- a/Earthfile
+++ b/Earthfile
@@ -12,6 +12,7 @@ ARG K3S_VERSION=latest
 ARG BASE_IMAGE_NAME=$(echo $BASE_IMAGE | grep -o [^/]*: | rev | cut -c2- | rev)
 ARG BASE_IMAGE_TAG=$(echo $BASE_IMAGE | grep -o :.* | cut -c2-)
 ARG K3S_VERSION_TAG=$(echo $K3S_VERSION | sed s/+/-/)
+ARG FIPS_ENABLED=false
 
 luet:
     FROM quay.io/luet/base:$LUET_VERSION
@@ -36,10 +37,17 @@ BUILD_GOLANG:
     COPY . ./
     ARG BIN
     ARG SRC
-    ENV CGO_ENABLED=0
     ARG VERSION
     ENV GO_LDFLAGS=" -X github.com/kairos-io/provider-k3s/pkg/version.Version=${VERSION} -w -s"
-    RUN go-build-static.sh -a -o ${BIN} ./${SRC}
+
+    IF $FIPS_ENABLED
+        RUN go-build-fips.sh -a -o ${BIN} ./${SRC}
+        RUN assert-fips.sh ${BIN}
+        RUN assert-static.sh ${BIN}
+    ELSE
+        RUN go-build-static.sh -a -o ${BIN} ./${SRC}
+    END
+
     SAVE ARTIFACT ${BIN} ${BIN} AS LOCAL build/${BIN}
 
 VERSION:
@@ -68,11 +76,22 @@ build-provider:
 
 build-provider-package:
     DO +VERSION
+    ARG TARGETARCH
     ARG VERSION=$(cat VERSION)
     FROM scratch
     COPY +build-provider/agent-provider-k3s /usr/local/system/providers/agent-provider-k3s
     COPY scripts /opt/k3s/scripts
-    SAVE IMAGE --push $IMAGE_REPOSITORY/provider-k3s:${VERSION}
+    SAVE IMAGE --push $IMAGE_REPOSITORY/provider-k3s:${VERSION}-${TARGETARCH}
+
+provider-package-merge:
+    BUILD --platform=linux/amd64 --platform=linux/arm64 +provider-package-pull
+
+provider-package-pull:
+    DO +VERSION
+    ARG VERSION=$(cat VERSION)
+    ARG TARGETARCH
+    FROM ${IMAGE_REPOSITORY}/provider-k3s:${VERSION}-${TARGETARCH}
+    SAVE IMAGE --push ${IMAGE_REPOSITORY}/provider-k3s:${VERSION}
 
 docker:
     DO +VERSION


### PR DESCRIPTION
## Problem

`provider-k3s` has **no FIPS build path at all** — no `FIPS_ENABLED` arg, no `go-build-fips.sh`, no FIPS registry target. This repo was left out of the FIPS rollout that `provider-rke2` got in `2b47553` (2023, reshaped in `0d7c34e`) and that `provider-canonical` / `provider-kubeadm` have had since their workflows were written.

The consequence is worse than a missing artifact. FIPS images for this provider **do** exist in `palette-images-fips`, and they are byte-identical copies of the non-FIPS build:

| image | `palette-images` vs `palette-images-fips` |
| --- | --- |
| `provider-k3s` v4.8.0 / v4.9.0 / v4.9.5 / v4.9.6 | **identical manifest digest** |
| `provider-rke2` v4.9.5, `provider-canonical` v4.9.3 | differ (genuinely separate builds) |

Pulling `palette-images-fips/edge/kairos-io/provider-k3s:v4.9.6` and inspecting the binary confirms it: **`sig.StandardCrypto`, zero boringcrypto symbols, 5.9 MB**. The `provider-rke2` FIPS binary at the same path shape has 28 boringcrypto markers and is 7.6 MB.

So anything consuming the FIPS k3s provider today is running a standard-crypto agent under a FIPS path.

## Change

Adopts the shape already proven in `provider-rke2` and `provider-canonical`:

- `ARG FIPS_ENABLED=false` in the Earthfile base, so it propagates to all targets
- `BUILD_GOLANG` branches to `go-build-fips.sh` + `assert-fips.sh` + `assert-static.sh` when FIPS is on. All three already ship in the `hardened-images/builder/golang` image this repo **already uses** — no new build dependency.
- Workflow matrix gains a `fips` axis: `false` → `palette-images`, `true` → `palette-images-fips`, on native amd64/arm64 runners
- Per-arch tags plus a `provider-package-merge` job publishing the multi-arch manifest under the plain version tag

Also drops `ENV CGO_ENABLED=0`, which was already a no-op — `go-build-static.sh` exports `CGO_ENABLED=1` itself.

## Verification

Run locally with earthly + docker, not inferred from reading:

| build | result |
| --- | --- |
| `+build-provider --FIPS_ENABLED=true` | ✅ `sig.BoringCrypto`, 28 markers, 7.3 MB static; `assert-fips.sh` and `assert-static.sh` both pass |
| `+build-provider-package --FIPS_ENABLED=false` | ✅ `sig.StandardCrypto`, tags `provider-k3s:v0.0.0-379ca475-amd64` |

arm64 FIPS is safe to include: the shipped `provider-rke2:v4.9.5-arm64` FIPS binary carries boringcrypto, so the native arm64 runner path is proven.

## Before merging

1. **Something is mirroring non-FIPS images into `palette-images-fips` for this provider.** It is not in this repo. Once this workflow pushes real FIPS images on the same tags, that mirror will race with or overwrite them — it needs to exclude `provider-k3s` first.
2. Confirm the `github-arm64-2c-8gb` runner is available to this repo. `provider-rke2` and `provider-canonical` use it, so it likely is, but a tag-triggered release workflow is the wrong place to find out otherwise.

Minor: `+provider-package-all-platforms` now yields only per-arch tags (same as `provider-rke2`). Anything calling that target directly outside CI needs `+provider-package-merge` too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
