### PR TITLE
docs: point issue reporting at kairos-io/kairos

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 
 ---
 
-> **Community supported, best effort.** This provider is moving to its own
-> organization. Until then, open issues on
-> [kairos-io/kairos](https://github.com/kairos-io/kairos/issues).
+> [!WARNING]
+> **Community supported.** This provider is moving to its own organization.
+> Until then, open issues on [kairos-io/kairos](https://github.com/kairos-io/kairos/issues)
+> for best effort support.
 
 This provider will configure a k3s installation based on the cluster section of cloud init.
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 ---
 
+> **Found a bug, or want to request a feature?** Open it on
+> [kairos-io/kairos](https://github.com/kairos-io/kairos/issues), including
+> issues about this repository. Every Kairos issue lives in one place, so you
+> never have to work out which repository to file against.
+
 This provider will configure a k3s installation based on the cluster section of cloud init.
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@
 > [kairos-io/kairos](https://github.com/kairos-io/kairos/issues), including
 > issues about this repository. Every Kairos issue lives in one place, so you
 > never have to work out which repository to file against.
+>
+> **This provider is community supported.** It is maintained on a best effort
+> basis, and it is moving to its own organization. Until it moves,
+> [kairos-io/kairos](https://github.com/kairos-io/kairos/issues) is still the
+> place to file. Expect community support and best effort, not a maintainer
+> response time.
 
 This provider will configure a k3s installation based on the cluster section of cloud init.
 

--- a/README.md
+++ b/README.md
@@ -2,16 +2,9 @@
 
 ---
 
-> **Found a bug, or want to request a feature?** Open it on
-> [kairos-io/kairos](https://github.com/kairos-io/kairos/issues), including
-> issues about this repository. Every Kairos issue lives in one place, so you
-> never have to work out which repository to file against.
->
-> **This provider is community supported.** It is maintained on a best effort
-> basis, and it is moving to its own organization. Until it moves,
-> [kairos-io/kairos](https://github.com/kairos-io/kairos/issues) is still the
-> place to file. Expect community support and best effort, not a maintainer
-> response time.
+> **Community supported, best effort.** This provider is moving to its own
+> organization. Until then, open issues on
+> [kairos-io/kairos](https://github.com/kairos-io/kairos/issues).
 
 This provider will configure a k3s installation based on the cluster section of cloud init.
 


### PR DESCRIPTION
Part of kairos-io/kairos#4364.

This repository has its Issues tab turned off, and the README does not say where to go instead. A user who wants to report a bug here finds nothing.

This adds one short note near the top of the README, pointing every report at kairos-io/kairos. The wording is the same in every repository this ticket touches, so the instruction reads identically wherever a user lands.

No behaviour changes. Documentation only.

_This pull request was opened with AI assistance. This is not an agent. Mauro used AI to help write it._
